### PR TITLE
Clear previous biometric accesses.

### DIFF
--- a/Sources/TIM/TIM.swift
+++ b/Sources/TIM/TIM.swift
@@ -164,7 +164,7 @@ public protocol TIMDataStorage {
     @available(iOS, deprecated: 13)
     func storeRefreshToken(_ refreshToken: JWT, withExistingPassword password: String, completion: @escaping (Result<Void, TIMError>) -> Void)
 
-    /// Stores refresh token with a new password.
+    /// Stores refresh token with a new password and removes current biometric access for potential previous refresh token.
     /// - Parameters:
     ///   - refreshToken: The refresh token.
     ///   - newPassword: The new password that needs a new encryption key.


### PR DESCRIPTION
When storing a refresh token with a new password, it will clear previous biometric accesses to make sure that old longSecrets isn't kept in the keychain.