### PR TITLE
Replacing JWT typealias with a JWT struct to guarantee user IDs and expire dates for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Most errors are helping you as a developer to figure out, what you might have co
 // Refresh token has expired
 TIMError.auth(TIMAuthError.refreshTokenExpired)
 
+// The user pressed cancel in the safari view controller during the OpenID Connect login
+TIMError.auth(TIMAuthError.safariViewControllerCancelled)
+
 TIMError.storage(
     TIMStorageError.encryptedStorageFailed(
         TIMEncryptedStorageError.keyServiceFailed(TIMKeyServiceError.badPassword)

--- a/Sources/TIM/Extensions/JWT+Extensions.swift
+++ b/Sources/TIM/Extensions/JWT+Extensions.swift
@@ -4,10 +4,10 @@ private let EXPIRE_KEY: String = "exp"
 private let SUB_KEY: String = "sub"
 
 /// Type alias for tokens - just a string.
-public typealias JWT = String
+public typealias JWTString = String
 
 /// Extensions for default data on a JWT.
-public extension JWT {
+extension JWTString {
 
     /// `exp` value
     var expireTimestamp: TimeInterval? {

--- a/Sources/TIM/Models/Errors.swift
+++ b/Sources/TIM/Models/Errors.swift
@@ -28,6 +28,7 @@ public enum TIMAuthError: Error, LocalizedError {
     case refreshTokenExpired
     case appAuthFailed(Error?)
     case safariViewControllerCancelled
+    case failedToGetRequiredDataInToken
 
     public var errorDescription: String? {
         switch self {
@@ -49,6 +50,8 @@ public enum TIMAuthError: Error, LocalizedError {
             return "Something went wrong in the AppAuth framework: \(error?.localizedDescription ?? "nil")"
         case .safariViewControllerCancelled:
             return "The user cancelled OpenID connect login via SafariViewController"
+        case .failedToGetRequiredDataInToken:
+            return "TIM did not find the required data (userId) in the token. The 'sub' property must be present in the token!"
         }
     }
 
@@ -86,14 +89,11 @@ public enum TIMAuthError: Error, LocalizedError {
 /// Errors related to storage operations
 public enum TIMStorageError: Error, LocalizedError {
     case encryptedStorageFailed(TIMEncryptedStorageError)
-    case noUserIdFoundInRefreshToken
 
     public var errorDescription: String? {
         switch self {
         case .encryptedStorageFailed(let error):
             return "The encrypted storage failed: \(error.localizedDescription)"
-        case .noUserIdFoundInRefreshToken:
-            return "TIM did not find any userId in the refresh token. The 'sub' property must be present!"
         }
     }
 
@@ -114,8 +114,6 @@ public enum TIMStorageError: Error, LocalizedError {
             default:
                 return false
             }
-        default:
-            return false
         }
     }
 
@@ -142,8 +140,6 @@ public enum TIMStorageError: Error, LocalizedError {
             } else {
                 isKeyServiceError = false
             }
-        default:
-            isKeyServiceError = false
         }
         return isKeyServiceError
     }

--- a/Sources/TIM/Models/TIMCallbackModels.swift
+++ b/Sources/TIM/Models/TIMCallbackModels.swift
@@ -4,8 +4,36 @@ import Foundation
 public struct BiometricRefreshToken {
 
     /// Refresh token
-    public let refreshToken: String
+    public let refreshToken: JWT
 
     /// Long secret used to load the refresh token
     public let longSecret: String
+}
+
+/// Wrapper class for a `JWTString`. This class is used to guarantee that a token always is accompanied with a valid userId and expire timestamp.
+public struct JWT {
+    /// JWT token
+    public let token: JWTString
+
+    /// User ID from token's `sub` parameter
+    public let userId: String
+
+    /// The expiration date from the `exp` parameter
+    /// This value is optional, since isn't required on refresh tokens.
+    public let expireDate: Date?
+
+    init?(token: JWTString) {
+        self.token = token
+        if let userId = token.userId {
+            self.userId = userId
+        } else {
+            return nil
+        }
+
+        if let expireTimestamp = token.expireTimestamp {
+            self.expireDate = Date(timeIntervalSince1970: expireTimestamp)
+        } else {
+            self.expireDate = nil
+        }
+    }
 }

--- a/Sources/TIM/TIMInternal/TIMAuthInternal.swift
+++ b/Sources/TIM/TIMInternal/TIMAuthInternal.swift
@@ -56,26 +56,26 @@ extension TIMAuthInternal {
     }
 
     func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool = true, completion: @escaping AccessTokenCallback) {
-        storage.getStoredRefreshToken(userId: userId, password: password) { (result: Result<String, TIMError>) in
+        storage.getStoredRefreshToken(userId: userId, password: password) { (result: Result<JWT, TIMError>) in
             switch result {
-            case .success(let refreshToken):
-                AppAuthController.shared.silentLogin(refreshToken: refreshToken) { (result: Result<JWT, TIMAuthError>) in
+            case .success(let refreshJWT):
+                AppAuthController.shared.silentLogin(refreshToken: refreshJWT) { (result: Result<JWT, TIMAuthError>) in
                     switch result {
-                    case .success(let accessToken):
+                    case .success(let accessJWT):
                         if let newRefreshToken = AppAuthController.shared.refreshToken() {
-                            TIM.logger?.log("Did get access token: %@", accessToken)
+                            TIM.logger?.log("Did get access token: %@", accessJWT.token)
                             if storeNewRefreshToken {
                                 self.storage.storeRefreshToken(newRefreshToken, withExistingPassword: password) { (result) in
                                     switch result {
                                     case .success:
-                                        completion(.success(accessToken))
+                                        completion(.success(accessJWT))
                                     case .failure(let error):
                                         TIM.logger?.log("Failed to store refresh token after silent login: %@", error.localizedDescription)
                                         completion(.failure(error))
                                     }
                                 }
                             } else {
-                                completion(.success(accessToken))
+                                completion(.success(accessJWT))
                             }
                         } else {
                             TIM.logger?.log("Failed to get access and refresh token via silent login.")
@@ -101,7 +101,7 @@ extension TIMAuthInternal {
                     switch result {
                     case .success(let accessToken):
                         if let newRefreshToken = AppAuthController.shared.refreshToken() {
-                            TIM.logger?.log("Did get access token: %@", accessToken)
+                            TIM.logger?.log("Did get access token: %@", accessToken.token)
                             if storeNewRefreshToken {
                                 self.storage.storeRefreshTokenWithBiometricAccess(
                                     newRefreshToken,

--- a/Tests/TIMTests/JWTExtensionTests.swift
+++ b/Tests/TIMTests/JWTExtensionTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class JWTExtensionsTests: XCTestCase {
 
-    let simpleAccessToken: JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxMzM3fQ.RfalLtiTT6j_rBKX5pGm_jGmwwL-hIh-Qut7eLHiwtg"
-    let invalidJwt: JWT = "INVALID"
+    let simpleAccessToken: JWTString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxMzM3fQ.RfalLtiTT6j_rBKX5pGm_jGmwwL-hIh-Qut7eLHiwtg"
+    let invalidJwt: JWTString = "INVALID"
 
     func testUserId() {
         XCTAssertEqual(simpleAccessToken.userId, "user")
@@ -18,9 +18,16 @@ final class JWTExtensionsTests: XCTestCase {
         XCTAssertNil(invalidJwt.userId)
     }
 
-    static var allTests = [
-        ("testUserId", testUserId),
-        ("testExpireTime", testExpireTime),
-        ("testInvalidToken", testInvalidToken),
-    ]
+    func testJWTInit() {
+        let jwt = JWT(token: simpleAccessToken)
+        XCTAssertNotNil(jwt)
+
+        // Missing exp
+        let jwtWithoutExp = JWT(token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+        XCTAssertNotNil(jwtWithoutExp)
+
+        // Missing sub
+        let jwtWithoutUserId = JWT(token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTUxNjIzOTAyMn0.yOZC0rjfSopcpJ-d3BWE8-BkoLR_SCqPdJpq8Wn-1Mc")
+        XCTAssertNil(jwtWithoutUserId)
+    }
 }

--- a/Tests/TIMTests/TIMStorageErrorTests.swift
+++ b/Tests/TIMTests/TIMStorageErrorTests.swift
@@ -4,7 +4,6 @@ import XCTest
 final class TIMStorageErrorTests: XCTestCase {
 
     func testIsKeyLocked() {
-        XCTAssertFalse(TIMStorageError.noUserIdFoundInRefreshToken.isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keychainFailed(.failedToLoadData)).isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badInternet)).isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badPassword)).isKeyLocked())
@@ -12,7 +11,6 @@ final class TIMStorageErrorTests: XCTestCase {
     }
 
     func testIsWrongPassword() {
-        XCTAssertFalse(TIMStorageError.noUserIdFoundInRefreshToken.isWrongPassword())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keychainFailed(.failedToStoreData)).isWrongPassword())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badInternet)).isWrongPassword())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.keyLocked)).isWrongPassword())
@@ -20,7 +18,6 @@ final class TIMStorageErrorTests: XCTestCase {
     }
 
     func testIsKeyServiceError() {
-        XCTAssertFalse(TIMStorageError.noUserIdFoundInRefreshToken.isKeyServiceError())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keychainFailed(.authenticationFailedForData)).isKeyServiceError())
         XCTAssertTrue(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badInternet)).isKeyServiceError())
         XCTAssertTrue(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.keyLocked)).isKeyServiceError())
@@ -28,7 +25,6 @@ final class TIMStorageErrorTests: XCTestCase {
     }
 
     func testIsBiometricError() {
-        XCTAssertFalse(TIMStorageError.noUserIdFoundInRefreshToken.isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keychainFailed(.failedToLoadData)).isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badInternet)).isKeyLocked())
         XCTAssertFalse(TIMStorageError.encryptedStorageFailed(.keyServiceFailed(.badPassword)).isKeyLocked())


### PR DESCRIPTION
The `JWT` struct cannot be constructed if the `userId` (`"sub"`) is missing in the token format.

With this implementation will the `JWT` instance always be guaranteed to be accompanied by a `userId` and `expireDate`.
TIM will throw `TIMAuthError.failedToGetRequiredDataInToken` if it fails to construct the `JWT` instance.

`TIMStorageError.noUserIdFoundInRefreshToken` was removed, since this case is now handled by the guaranteed `JWT.userId` instead.