### PR TITLE
AuthorizationRequest nonce

### DIFF
--- a/Sources/TIM/AppAuth/AppAuthController.swift
+++ b/Sources/TIM/AppAuth/AppAuthController.swift
@@ -241,21 +241,12 @@ public final class AppAuthController: OpenIDConnectController {
     
     /// Create AuthorizationRequest using the authorizationRequestNonce in case it is provided
     private func createAuthorizationRequest(config: OIDServiceConfiguration, authorizationRequestNonce: String?) -> OIDAuthorizationRequest {
-        if authorizationRequestNonce == nil {
-            return OIDAuthorizationRequest(
-                configuration: config,
-                clientId: self.credentials.clientId,
-                scopes: self.credentials.scopes,
-                redirectURL: self.credentials.redirectUri,
-                responseType: OIDResponseTypeCode,
-                additionalParameters: [:]
-            )
-        } else {
+        if let authorizationRequestNonce = authorizationRequestNonce {
             return OIDAuthorizationRequest(
                 configuration: config,
                 clientId: self.credentials.clientId,
                 clientSecret: nil,
-                scope: self.credentials.scopes.joined(separator: " "),
+                scope: OIDScopeUtilities.scopes(with: self.credentials.scopes),
                 redirectURL: self.credentials.redirectUri,
                 responseType: OIDResponseTypeCode,
                 state: nil,
@@ -263,6 +254,15 @@ public final class AppAuthController: OpenIDConnectController {
                 codeVerifier: nil,
                 codeChallenge: nil,
                 codeChallengeMethod: nil,
+                additionalParameters: [:]
+            )
+        } else {
+            return OIDAuthorizationRequest(
+                configuration: config,
+                clientId: self.credentials.clientId,
+                scopes: self.credentials.scopes,
+                redirectURL: self.credentials.redirectUri,
+                responseType: OIDResponseTypeCode,
                 additionalParameters: [:]
             )
         }

--- a/Sources/TIM/AppAuth/AppAuthController.swift
+++ b/Sources/TIM/AppAuth/AppAuthController.swift
@@ -5,7 +5,7 @@ import SafariServices
 /// Protocol for OpenID Connect dependency.
 public protocol OpenIDConnectController {
     var isLoggedIn: Bool { get }
-    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?)
+    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?)
     func silentLogin(refreshToken: JWT, completion: @escaping (Result<JWT, TIMAuthError>) -> Void)
     func accessToken(forceRefresh: Bool, _ completion: @escaping (Result<JWT, TIMAuthError>) -> Void)
     func refreshToken() -> JWT?
@@ -86,7 +86,8 @@ public final class AppAuthController: OpenIDConnectController {
                 completion: @escaping ((Result<JWT, TIMAuthError>) -> Void),
                 didCancel: (() -> Void)? = nil,
                 willPresentSafariViewController: ((SFSafariViewController) -> Void)? = nil,
-                shouldAnimate: (() -> Bool)? = nil) {
+                shouldAnimate: (() -> Bool)? = nil,
+                authorizationRequestNonce: String? = nil) {
         discoverConfiguration { [weak self] (res: Result<OIDServiceConfiguration, TIMAuthError>) in
             guard let `self` = self else {
                 return
@@ -94,14 +95,8 @@ public final class AppAuthController: OpenIDConnectController {
 
             switch res {
             case .success(let config):
-                let request = OIDAuthorizationRequest(
-                    configuration: config,
-                    clientId: self.credentials.clientId,
-                    scopes: self.credentials.scopes,
-                    redirectURL: self.credentials.redirectUri,
-                    responseType: OIDResponseTypeCode,
-                    additionalParameters: [:]
-                )
+                let request = self.createAuthorizationRequest(config: config, authorizationRequestNonce: authorizationRequestNonce)
+                
                 self.doAuthState(
                     request: request,
                     presentingViewController: presentingViewController,
@@ -241,6 +236,35 @@ public final class AppAuthController: OpenIDConnectController {
         DispatchQueue.main.async {
             preCompletionAction?(result)
             completion(result)
+        }
+    }
+    
+    /// Create AuthorizationRequest using the authorizationRequestNonce in case it is provided
+    private func createAuthorizationRequest(config: OIDServiceConfiguration, authorizationRequestNonce: String?) -> OIDAuthorizationRequest {
+        if authorizationRequestNonce == nil {
+            return OIDAuthorizationRequest(
+                configuration: config,
+                clientId: self.credentials.clientId,
+                scopes: self.credentials.scopes,
+                redirectURL: self.credentials.redirectUri,
+                responseType: OIDResponseTypeCode,
+                additionalParameters: [:]
+            )
+        } else {
+            return OIDAuthorizationRequest(
+                configuration: config,
+                clientId: self.credentials.clientId,
+                clientSecret: nil,
+                scope: self.credentials.scopes.joined(separator: " "),
+                redirectURL: self.credentials.redirectUri,
+                responseType: OIDResponseTypeCode,
+                state: nil,
+                nonce: authorizationRequestNonce,
+                codeVerifier: nil,
+                codeChallenge: nil,
+                codeChallengeMethod: nil,
+                additionalParameters: [:]
+            )
         }
     }
 

--- a/Sources/TIM/AppAuth/AppAuthControllerMock.swift
+++ b/Sources/TIM/AppAuth/AppAuthControllerMock.swift
@@ -13,7 +13,7 @@ final class AppAuthControllerMock: OpenIDConnectController {
     private var rt: JWTString?
     private var at: JWTString?
 
-    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?) {
+    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?) {
         guard let atJwt = JWT(token: mockAT), let rtJwt = JWT(token: mockRT) else {
             completion(.failure(.failedToGetAccessToken))
             return

--- a/Sources/TIM/Protocols/TIMAuth.swift
+++ b/Sources/TIM/Protocols/TIMAuth.swift
@@ -36,7 +36,7 @@ public protocol TIMAuth {
     ///   - presentingViewController: The view controller which the safari view controller should be presented on.
     ///   - completion: Invoked with access token after successful login (or with error)
     @available(iOS, deprecated: 13)
-    func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback)
+    func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback, authorizationRequestNonce: String?)
 
     /// Logs in using password. This can only be done if the user has stored the refresh token with a password after calling `performOpenIDConnectLogin`.
     /// - Parameters:
@@ -81,9 +81,9 @@ public extension TIMAuth {
 
     /// Combine wrapper of `performOpenIDConnectLogin(presentingViewController:completion:)`
     @available(iOS 13, *)
-    func performOpenIDConnectLogin(presentingViewController: UIViewController) -> Future<JWT, TIMError> {
+    func performOpenIDConnectLogin(presentingViewController: UIViewController, authorizationRequestNonce: String? = nil) -> Future<JWT, TIMError> {
         Future { promise in
-            self.performOpenIDConnectLogin(presentingViewController: presentingViewController, completion: promise)
+            self.performOpenIDConnectLogin(presentingViewController: presentingViewController, completion: promise, authorizationRequestNonce: authorizationRequestNonce)
         }
     }
 

--- a/Sources/TIM/Protocols/TIMAuth.swift
+++ b/Sources/TIM/Protocols/TIMAuth.swift
@@ -69,7 +69,17 @@ public protocol TIMAuth {
     func disableBackgroundTimeout()
 }
 
+/// Default parameters
+public extension TIMAuth {
+    /// Wrapper of `performOpenIDConnectLogin(presentingViewController:completion:authorizationRequestNonce)` adding nil as default value for authorizationRequestNonce
+    func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback, authorizationRequestNonce: String? = nil) {
+        self.performOpenIDConnectLogin(presentingViewController: presentingViewController, completion: completion, authorizationRequestNonce: authorizationRequestNonce)
+    }
+}
+
+
 #if canImport(Combine)
+/// Combine wrappers
 public extension TIMAuth {
     /// Combine wrapper of `accessToken(_:)`
     @available(iOS 13, *)
@@ -78,8 +88,8 @@ public extension TIMAuth {
             self.accessToken(promise)
         }
     }
-
-    /// Combine wrapper of `performOpenIDConnectLogin(presentingViewController:completion:)`
+    
+    /// Combine wrapper of `performOpenIDConnectLogin(presentingViewController:completion:authorizationRequestNonce)`
     @available(iOS 13, *)
     func performOpenIDConnectLogin(presentingViewController: UIViewController, authorizationRequestNonce: String? = nil) -> Future<JWT, TIMError> {
         Future { promise in

--- a/Sources/TIM/Protocols/TIMAuth.swift
+++ b/Sources/TIM/Protocols/TIMAuth.swift
@@ -72,8 +72,8 @@ public protocol TIMAuth {
 /// Default parameters
 public extension TIMAuth {
     /// Wrapper of `performOpenIDConnectLogin(presentingViewController:completion:authorizationRequestNonce)` adding nil as default value for authorizationRequestNonce
-    func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback, authorizationRequestNonce: String? = nil) {
-        self.performOpenIDConnectLogin(presentingViewController: presentingViewController, completion: completion, authorizationRequestNonce: authorizationRequestNonce)
+    func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback) {
+        self.performOpenIDConnectLogin(presentingViewController: presentingViewController, completion: completion, authorizationRequestNonce: nil)
     }
 }
 

--- a/Sources/TIM/TIMInternal/TIMAuthDefault.swift
+++ b/Sources/TIM/TIMInternal/TIMAuthDefault.swift
@@ -47,7 +47,7 @@ extension TIMAuthDefault {
         }
     }
 
-    public func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback) {
+    public func performOpenIDConnectLogin(presentingViewController: UIViewController, completion: @escaping AccessTokenCallback, authorizationRequestNonce: String? = nil) {
         openIdController.login(
             presentingViewController: presentingViewController,
             completion: { (result: Result<JWT, TIMAuthError>) in
@@ -57,7 +57,8 @@ extension TIMAuthDefault {
                 completion(.failure(TIMError.auth(.safariViewControllerCancelled)))
             },
             willPresentSafariViewController: nil,
-            shouldAnimate: nil
+            shouldAnimate: nil,
+            authorizationRequestNonce: authorizationRequestNonce
         )
     }
 


### PR DESCRIPTION
Added optional authorizationRequestNonce parameter to performOpenIDConnectLogin making it possible to define a custom nonce for the authorization request.