### PR TITLE
Niha/external user agent session

### DIFF
--- a/Sources/TIM/AppAuth/AppAuthController.swift
+++ b/Sources/TIM/AppAuth/AppAuthController.swift
@@ -5,7 +5,7 @@ import SafariServices
 /// Protocol for OpenID Connect dependency.
 public protocol OpenIDConnectController {
     var isLoggedIn: Bool { get }
-    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?)
+    func login(presentingViewController: UIViewController?, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?)
     func silentLogin(refreshToken: JWT, completion: @escaping (Result<JWT, TIMAuthError>) -> Void)
     func accessToken(forceRefresh: Bool, _ completion: @escaping (Result<JWT, TIMAuthError>) -> Void)
     func refreshToken() -> JWT?
@@ -47,11 +47,17 @@ public final class AppAuthController: OpenIDConnectController {
 
     private func doAuthState(
         request: OIDAuthorizationRequest,
-        presentingViewController: UIViewController,
+        presentingViewController: UIViewController?,
         willPresentSafariViewController: @escaping (SFSafariViewController) -> Void,
         shouldAnimate: @escaping () -> Bool,
         didCancel: @escaping () -> Void,
         callback: @escaping (Result<OIDAuthState, TIMAuthError>) -> Void) {
+            
+            guard customOIDExternalUserAgent != nil || presentingViewController != nil, let presentingViewController else {
+                callback(.failure(.noUserAgent))
+                return
+            }
+            
             let externalUserAgent = customOIDExternalUserAgent ?? AuthSFController(
                 presentingViewController: presentingViewController,
                 willPresentSafariViewControllerCallback: willPresentSafariViewController,
@@ -86,7 +92,7 @@ public final class AppAuthController: OpenIDConnectController {
             parameters: [:])
     }
 
-    public func login(presentingViewController: UIViewController,
+    public func login(presentingViewController: UIViewController?,
                 completion: @escaping ((Result<JWT, TIMAuthError>) -> Void),
                 didCancel: (() -> Void)? = nil,
                 willPresentSafariViewController: ((SFSafariViewController) -> Void)? = nil,

--- a/Sources/TIM/AppAuth/AppAuthController.swift
+++ b/Sources/TIM/AppAuth/AppAuthController.swift
@@ -53,13 +53,13 @@ public final class AppAuthController: OpenIDConnectController {
         didCancel: @escaping () -> Void,
         callback: @escaping (Result<OIDAuthState, TIMAuthError>) -> Void) {
             
-            guard customOIDExternalUserAgent != nil || presentingViewController != nil, let presentingViewController else {
+            guard customOIDExternalUserAgent != nil || presentingViewController != nil else {
                 callback(.failure(.noUserAgent))
                 return
             }
             
             let externalUserAgent = customOIDExternalUserAgent ?? AuthSFController(
-                presentingViewController: presentingViewController,
+                presentingViewController: presentingViewController!,
                 willPresentSafariViewControllerCallback: willPresentSafariViewController,
                 shouldAnimateCallback: shouldAnimate,
                 didCancelCallback: didCancel

--- a/Sources/TIM/AppAuth/AppAuthControllerMock.swift
+++ b/Sources/TIM/AppAuth/AppAuthControllerMock.swift
@@ -13,7 +13,7 @@ final class AppAuthControllerMock: OpenIDConnectController {
     private var rt: JWTString?
     private var at: JWTString?
 
-    func login(presentingViewController: UIViewController, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?) {
+    func login(presentingViewController: UIViewController?, completion: @escaping ((Result<JWT, TIMAuthError>) -> Void), didCancel: (() -> Void)?, willPresentSafariViewController: ((SFSafariViewController) -> Void)?, shouldAnimate: (() -> Bool)?, authorizationRequestNonce: String?) {
         guard let atJwt = JWT(token: mockAT), let rtJwt = JWT(token: mockRT) else {
             completion(.failure(.failedToGetAccessToken))
             return

--- a/Sources/TIM/AppAuth/AuthSFController.swift
+++ b/Sources/TIM/AppAuth/AuthSFController.swift
@@ -10,11 +10,13 @@ public class AuthSFController: OIDExternalUserAgentIOS, SFSafariViewControllerDe
 
     /// User taps on cancel in SFSafariViewController
     private var didCancel: () -> Void
-
-    public required init?(presentingViewController: UIViewController,
-                          willPresentSafariViewControllerCallback: @escaping (SFSafariViewController) -> Void,
-                          shouldAnimateCallback: @escaping () -> Bool,
-                          didCancelCallback: @escaping () -> Void) {
+    
+    public required init?(
+        presentingViewController: UIViewController,
+        willPresentSafariViewControllerCallback: @escaping (SFSafariViewController) -> Void,
+        shouldAnimateCallback: @escaping () -> Bool,
+        didCancelCallback: @escaping () -> Void
+    ) {
         self.shouldAnimateCallback = shouldAnimateCallback
         self.willPresentSafariViewController = willPresentSafariViewControllerCallback
         self.presentingViewController = presentingViewController

--- a/Sources/TIM/Models/Errors.swift
+++ b/Sources/TIM/Models/Errors.swift
@@ -30,6 +30,7 @@ public enum TIMAuthError: Error, LocalizedError {
     case safariViewControllerCancelled
     case failedToGetRequiredDataInToken
     case failedToValidateIDToken
+    case noUserAgent
 
     public var errorDescription: String? {
         switch self {
@@ -55,6 +56,8 @@ public enum TIMAuthError: Error, LocalizedError {
             return "TIM did not find the required data (userId) in the token. The 'sub' property must be present in the token!"
         case .failedToValidateIDToken:
             return "AppAuth failed to validate the ID Token. This will happen if the client's time is more than 10 minutes off the current time."
+        case .noUserAgent:
+            return "No user agent set up! Set a 'presentingViewController' or a custom 'OIDExternalUserAgentIOS' on init."
         }
     }
 

--- a/Sources/TIM/Protocols/TIMAuth.swift
+++ b/Sources/TIM/Protocols/TIMAuth.swift
@@ -38,6 +38,14 @@ public protocol TIMAuth {
     ///   - completion: Invoked with access token after successful login (or with error)
     @available(iOS, deprecated: 13)
     func performOpenIDConnectLogin(presentingViewController: UIViewController, authorizationRequestNonce: String?, completion: @escaping AccessTokenCallback)
+    
+    /// Performs OAuth login with OpenID Connect by presenting a custom `OIDExternalUserAgentIOS`. For this to work, remember to set up a custom useragent when configuring TIM.
+    ///
+    /// The `refreshToken` property will be available after this, which can be used to encrypt and store it in the secure store by the `storage` namespace.
+    /// - Parameters:
+    ///   - completion: Invoked with access token after successful login (or with error)
+    @available(iOS, deprecated: 13)
+    func performOpenIDConnectLogin(authorizationRequestNonce: String?, completion: @escaping AccessTokenCallback)
 
     /// Logs in using password. This can only be done if the user has stored the refresh token with a password after calling `performOpenIDConnectLogin`.
     /// - Parameters:

--- a/Sources/TIM/Protocols/TIMAuth.swift
+++ b/Sources/TIM/Protocols/TIMAuth.swift
@@ -115,6 +115,14 @@ public extension TIMAuth {
             self.performOpenIDConnectLogin(presentingViewController: presentingViewController, authorizationRequestNonce: authorizationRequestNonce, completion: promise)
         }
     }
+    
+    /// Combine wrapper of `performOpenIDConnectLogin(completion:authorizationRequestNonce)`
+    @available(iOS 13, *)
+    func performOpenIDConnectLogin(authorizationRequestNonce: String? = nil) -> Future<JWT, TIMError> {
+        Future { promise in
+            self.performOpenIDConnectLogin(authorizationRequestNonce: authorizationRequestNonce, completion: promise)
+        }
+    }
 
     /// Combine wrapper of `loginWithPassword(userId:password:storeNewRefreshToken:completion:)`
     @available(iOS 13, *)

--- a/Sources/TIM/TIM.swift
+++ b/Sources/TIM/TIM.swift
@@ -51,7 +51,8 @@ public final class TIM {
     ///   - configuration: TIMConfiguration
     ///   - customLogger: An optional custom logger for logging messages internally from `TIM`. Set to `nil` to disable logging.
     ///   - allowReconfigure: Controls whether you are allowed to call this method multiple times. It is **discouraged**, but possible if really needed... Default value is `false`.
-    public static func configure(
+    ///   - customOIDExternalUserAgent: A custom user agent for displaying the actual loginview. Using a `SFSafariViewController` is best practice. It's strongly discouraged to use `UIWebView` or `WKWebView` for security reasons.
+     public static func configure(
         configuration: TIMConfiguration,
         customLogger: TIMLoggerProtocol? = TIMLogger(),
         allowReconfigure: Bool = false,

--- a/Sources/TIM/TIMInternal/TIMAuthDefault.swift
+++ b/Sources/TIM/TIMInternal/TIMAuthDefault.swift
@@ -61,6 +61,21 @@ extension TIMAuthDefault {
             authorizationRequestNonce: authorizationRequestNonce
         )
     }
+    
+    public func performOpenIDConnectLogin(authorizationRequestNonce: String?, completion: @escaping AccessTokenCallback) {
+        openIdController.login(
+            presentingViewController: nil,
+            completion: { (result: Result<JWT, TIMAuthError>) in
+                completion(result.mapError({ TIMError.auth($0) }))
+            },
+            didCancel: {
+                completion(.failure(TIMError.auth(.safariViewControllerCancelled)))
+            },
+            willPresentSafariViewController: nil,
+            shouldAnimate: nil,
+            authorizationRequestNonce: authorizationRequestNonce
+        )
+    }
 
     public func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool = true, completion: @escaping AccessTokenCallback) {
         storage.getStoredRefreshToken(userId: userId, password: password) { (result: Result<JWT, TIMError>) in

--- a/Sources/TIM/TIMInternal/TIMAuthDefault.swift
+++ b/Sources/TIM/TIMInternal/TIMAuthDefault.swift
@@ -68,9 +68,7 @@ extension TIMAuthDefault {
             completion: { (result: Result<JWT, TIMAuthError>) in
                 completion(result.mapError({ TIMError.auth($0) }))
             },
-            didCancel: {
-                completion(.failure(TIMError.auth(.safariViewControllerCancelled)))
-            },
+            didCancel: { }, // Handle this in the custom view
             willPresentSafariViewController: nil,
             shouldAnimate: nil,
             authorizationRequestNonce: authorizationRequestNonce


### PR DESCRIPTION
This PR allows the user to use a custom `OIDExternalUserAgentIOS`, to present the OAuth view in a custom view, to not limit logins to the default SFSafariViewController as implemented in the current solution.
Right now the login view is always presented with a push to a SFSafariViewController. This is not always ideal/wanted, hence this change.

I've made it backwards compatible, so it shouldn't interfere with existing implementations.